### PR TITLE
Avoid overflowing when it takes over 60s

### DIFF
--- a/src/components/QuizEnding.vue
+++ b/src/components/QuizEnding.vue
@@ -17,7 +17,7 @@
         <div class="progress">
           <div class="fill"
                :style="{
-                 width: `${ (times[i] * 100) / maxQuestionTime }%`,
+                 width: `${ Math.min((times[i] * 100) / maxQuestionTime, 100) }%`,
                  backgroundColor: color(times[i])
                }"
           ></div>


### PR DESCRIPTION
<img width="294" alt="Captura de pantalla 2020-07-23 a las 19 57 05" src="https://user-images.githubusercontent.com/11427028/88328350-3597a680-cd20-11ea-8227-f909b4a82d4c.png">

😜